### PR TITLE
Added #cc-dev-search channel

### DIFF
--- a/content/community/contents.lr
+++ b/content/community/contents.lr
@@ -58,6 +58,8 @@ The channels most relevant to CC's developer community are:
 | `#cc-dev-workprograms` | **GSoC, GSoD, Outreachy, and other [work programs][workprograms] or internships** |
 | `#cc-developers` | **general technical issues, new tech blog posts, etc.** |
 | `#cc-usability` | general usability issues, seeking feedback on new releases of CC products from the community, etc. |
+| `#cc-usability` | general usability issues, seeking feedback on new releases of CC products from the community, etc. |
+| `#cc-dev-searchportal`| Discussions regarding the Search portal|
 
 [legaldb]: https://github.com/creativecommons/legaldb
 [cc-chooser]: https://github.com/creativecommons/cc-chooser


### PR DESCRIPTION
According to issue #680. I have added the `#cc-dev-search channel ` to the slack channel list.